### PR TITLE
Add Pollinations AI as a free provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Free Pollinations.ai fallback provider** - When no API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`) is configured, the tool now automatically falls back to the free [Pollinations.ai](https://pollinations.ai) text generation API instead of exiting with an error.
+- URL encoding support for Pollinations.ai prompts with `python3` and `sed` fallback.
+- Updated `--help` text to document the free fallback option.
+
+## [1.0.0] - Initial Release
+
+### Added
+
+- Natural language to shell command conversion.
+- Support for OpenAI, Anthropic, and Gemini API providers.
+- Automatic model fallback within each provider.
+- Configuration persistence in `~/.x/config`.
+- `--verbose` flag for debug output.
+- `--version` flag to display version information.
+- `--upgrade` flag for self-updating.
+- Interactive command confirmation before execution.
+


### PR DESCRIPTION
## Summary

This PR adds support for Pollinations.ai as a free fallback provider when no API key is configured, allowing users to use x immediately without any setup.

### Motivation

Previously, users had to configure an API key (OpenAI, Anthropic, or Gemini) before using x. This created a barrier for:
- New users who want to try the tool quickly
- Users who don't have paid API accounts
- Casual/infrequent users

### Tested locally

<img width="916" height="171" alt="image" src="https://github.com/user-attachments/assets/fcaa81a2-7cdf-4f61-9249-4790f345d828" />
